### PR TITLE
解决在 iOS + iframe 的环境下，在 mip1 环境下运行正常的 mip-fixed 组件到了 mip2 环境不符合预期

### DIFF
--- a/lib/extension-item.js
+++ b/lib/extension-item.js
@@ -182,7 +182,7 @@ ExtensionItem.prototype.getDefaultBuildProcessors = function () {
                         '(window.MIP = window.MIP || []).push({'
                             + 'name:"' + name + '",'
                             + 'func: function () {'
-                                + mainFile.getData() + content + '\n\n'
+                                + mainFile.getData().replace(/<mip-fixed\s/g, '<mip-fixed still ') + content + '\n\n'
                             + '}'
                         + '});'
                     );

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "mip-extension-optimizer",
     "description": "MIP Extension Optimizer",
-    "version": "1.1.5",
+    "version": "1.1.6",
     "bin": {
         "mip-extension-optimise": "./bin/main"
     },


### PR DESCRIPTION
背景：

mip2 为了解决 iOS + iframe 环境下 fixed 元素滚动抖动的bug，所以将 mip-fixed 元素统一挪到了 body 外进行统一管理。目前较多的 mip2 的站点和组件正在使用这种机制管理 mip-fixed 的 z-index 层级，并且滚动体验非常好。（所以无法回退回 mip-fixed 最原始状态）。

但是通过查询 mip1 的组件库，发现有部分组件使用了 mip-fixed，而且会操作 mip-fixed 的 dom，由于 mip2 会移动 mip-fixed 元素本来的位置，导致组件获取不到 dom 会引发问题（前提是站点更新了 mip2）。所以 mip2 设计了一套 `still`  的机制，发现有 `still` 属性就不会移动 mip-fixed，在表现上和 mip1 保持一致。

解决方案：

通过构建工具，将所有的 mip1 组件库中插入的 mip-fixed 标签统一加上 still 属性。